### PR TITLE
Add build node security group, and automate server install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ secrets.tfvars
 !example_secrets.tfvars
 *.keys
 *.license
+admin.creds

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ tf_chef_automate is a blueprint for creating your own [Chef Automate](https://ww
 1. Run `terraform plan -var-file secrets.tfvars`.
 1. Run `terraform apply -var-file secrets.tfvars`.
 1. Create a new private repo and commit your `terraform.tfvars`, `terraform.tfstate`, and any changes to your own repository.
+
+# Builder keys
+
+You must provide a public/private builder key pair. They must be in ``.keys/builder_key` and ``.keys/builder_key.pub` for now.
+
+You can generate them using `ssh-keygen -t rsa`, or however you prefer to generate your ssh keys.

--- a/chef_automate.tpl
+++ b/chef_automate.tpl
@@ -1,10 +1,6 @@
-# download and install Chef Automate
-sudo curl -o /home/ec2-user/delivery-0.5.204-1.el7.x86_64.rpm -L https://packages.chef.io/stable/el/7/delivery-0.5.204-1.el7.x86_64.rpm
-sudo rpm -Uvh -i /home/ec2-user/delivery-0.5.204-1.el7.x86_64.rpm
-
-sudo delivery-ctl setup --license ~/chef_automate.license --key ${chef_automate_user_key} --server-url https://${chef_server_public_dns}/organizations/${chef_automate_org} --fqdn ${chef_automate_public_dns} --configure
-delivery-ctl create-enterprise ${enterprise_name} --ssh-pub-key-file=/etc/delivery/builder_key.pub
-
-sudo curl -o /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm -L https://packages.chef.io/stable/el/7/chefdk-0.17.17-1.el7.x86_64.rpm
-
-# delivery-ctl install-build-node --fqdn $BUILD_NODE_FQDN --username $SSH_USERNAME --password $SSH_PASSWORD --installer $CHEF_DK_PACKAGE_PATH --ssh-identity-file $SSH_IDENTITY_FILE --port $SSH_PORT --overwrite-registration
+delivery_fqdn "${chef_automate_public_dns}"
+delivery['chef_username']    = "chef_automate"
+delivery['chef_private_key'] = "/etc/delivery/chef_automate.pem"
+delivery['chef_server']      = "https://${chef_server_public_dns}/organizations/delivery"
+delivery['default_search']   = "((recipes:delivery_build OR tags:delivery-build-node OR recipes:delivery_build\\\\\\\\:\\\\\\\\:default) AND chef_environment:_default)"
+insights['enable'] = true

--- a/chef_automate.tpl
+++ b/chef_automate.tpl
@@ -1,6 +1,6 @@
 delivery_fqdn "${chef_automate_public_dns}"
 delivery['chef_username']    = "chef_automate"
-delivery['chef_private_key'] = "/etc/delivery/chef_automate.pem"
+delivery['chef_private_key'] = "/etc/delivery/delivery.pem"
 delivery['chef_server']      = "https://${chef_server_public_dns}/organizations/delivery"
 delivery['default_search']   = "((recipes:delivery_build OR tags:delivery-build-node OR recipes:delivery_build\\\\\\\\:\\\\\\\\:default) AND chef_environment:_default)"
 insights['enable'] = true

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "ingress_chef_server_allow_10000-10003_tcp" {
   security_group_id = "${aws_security_group.chef_server.id}"
 }
 
-# Allow all Chef 
+# Allow all Chef
 resource "aws_security_group_rule" "ingress_chef_server_allow_all_chef_automate" {
   type = "ingress"
   from_port = 0
@@ -183,6 +183,46 @@ resource "aws_security_group_rule" "egress_chef_automate_allow_0-65535_all" {
   security_group_id = "${aws_security_group.chef_automate.id}"
 }
 
+resource "aws_security_group" "build_nodes" {
+  name        = "build_nodes_${var.automate_instance_id}"
+  description = "Terraform Build Nodes"
+  vpc_id      = "${var.automate_vpc}"
+
+  tags {
+    Name = "${var.automate_tag}_build_nodes_security_group"
+  }
+}
+
+# Egress: ALL
+resource "aws_security_group_rule" "egress_build_nodes_allow_0-65535_all" {
+  type = "egress"
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.build_nodes.id}"
+}
+
+# SSH - all
+resource "aws_security_group_rule" "ingress_build_nodes_allow_22_tcp_all" {
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.build_nodes.id}"
+}
+
+# Allow all Chef Automate
+resource "aws_security_group_rule" "ingress_build_nodes_allow_all_chef_server" {
+  type = "ingress"
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+  source_security_group_id = "${aws_security_group.chef_automate.id}"
+  security_group_id = "${aws_security_group.build_nodes.id}"
+}
+
 data "template_file" "chef_server" {
   template = "${file("./chef_server.tpl")}"
 }
@@ -198,9 +238,9 @@ resource "aws_instance" "chef_server" {
   key_name        = "${var.aws_key_pair_name}"
   subnet_id       = "${aws_subnet.automate_subnet.id}"
   security_groups = ["${aws_security_group.chef_server.id}"]
-  
+
   ebs_optimized   = true
-  
+
   root_block_device {
     delete_on_termination = true
     volume_size = 100
@@ -240,6 +280,47 @@ resource "aws_instance" "chef_server" {
   }
 }
 
+resource "aws_instance" "build_nodes" {
+  connection {
+    user     = "${var.aws_ami_user}"
+    key_file = ".keys/${var.aws_key_pair_name}.pem"
+  }
+
+  ami             = "${var.aws_ami_rhel}"
+  instance_type   = "${var.aws_build_node_instance_type}"
+  key_name        = "${var.aws_key_pair_name}"
+  subnet_id       = "${aws_subnet.automate_subnet.id}"
+  security_groups = ["${aws_security_group.build_nodes.id}"]
+  ebs_optimized   = false
+  count = 3
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size = 20
+    volume_type = "io1"
+    iops        = 1000
+  }
+
+  tags {
+    Name      = "${format("${var.automate_tag}_build_node_%02d", count.index + 1)}"
+    X-Project = "CSE"
+  }
+
+  # We've got to do this for now because delivery-ctl install-build-node will not allow you to execute without a value in password.
+  # My workaround is to create a user with a password and sudo, use that one to auth, then we'll delete it later?
+  # The real solution is a PR to automate.
+  # TODO: PR to automate, Cleanup remote exec after
+  # (Or, I'm missing something obvious.)
+  provisioner "remote-exec" {
+    inline = [
+      "sudo useradd chef -p \\$6\\$sBhkyEwj\\$NZAqoAs3zFOygX2nH.wouLwe6h3zMgXnp3IVgLCTzrsJn1hVUU8qmH3kzyQCAVwtRGOQpfrZKvwtUx\\/1qWZjq0",
+      "sudo echo 'chef ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/80-chef-users",
+      "sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
+      "sudo service sshd restart",
+    ]
+  }
+}
+
 resource "aws_instance" "chef_automate" {
   connection {
     user     = "${var.aws_ami_user}"
@@ -252,7 +333,7 @@ resource "aws_instance" "chef_automate" {
   subnet_id       = "${aws_subnet.automate_subnet.id}"
   security_groups = ["${aws_security_group.chef_automate.id}"]
   ebs_optimized   = true
-  
+
   root_block_device {
     delete_on_termination = true
     volume_size = 100
@@ -273,13 +354,67 @@ resource "aws_instance" "chef_automate" {
     ]
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "sudo curl -o /home/ec2-user/delivery-0.5.204-1.el7.x86_64.rpm -L https://packages.chef.io/stable/el/7/delivery-0.5.204-1.el7.x86_64.rpm",
+      "sudo rpm -Uvh -i /home/ec2-user/delivery-0.5.204-1.el7.x86_64.rpm"
+    ]
+  }
+}
+
+data "template_file" "chef_automate" {
+  template = "${file("./chef_automate.tpl")}"
+  vars {
+    chef_server_public_dns = "${aws_instance.chef_server.public_dns}",
+    chef_automate_public_dns = "${aws_instance.chef_automate.public_dns}"
+  }
+}
+
+resource "null_resource" "automate_setup" {
+  connection {
+    user     = "${var.aws_ami_user}"
+    key_file = ".keys/${var.aws_key_pair_name}.pem"
+    host     = "${aws_instance.chef_automate.public_dns}"
+  }
   provisioner "file" {
     source      = "chef_automate.license"
     destination = "~/chef_automate.license"
   }
-
   provisioner "file" {
     source      = ".keys/chef_automate.pem"
     destination = "~/chef_automate.pem"
+  }
+  provisioner "file" {
+    content      = "${data.template_file.chef_automate.rendered}"
+    destination = "~/delivery.rb"
+  }
+  provisioner "file" {
+    source      = ".keys/builder_key"
+    destination = "~/builder_key"
+  }
+  provisioner "file" {
+    source      = ".keys/builder_key.pub"
+    destination = "~/builder_key.pub"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo curl -o /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm -L https://packages.chef.io/stable/el/7/chefdk-0.17.17-1.el7.x86_64.rpm",
+      "sudo mkdir /etc/delivery",
+      "sudo cp /home/ec2-user/chef_automate.pem /etc/delivery",
+      "sudo cp /home/ec2-user/delivery.rb /etc/delivery",
+      "sudo mkdir -p /var/opt/delivery/license/",
+      "sudo cp /home/ec2-user/chef_automate.license /var/opt/delivery/license/delivery.license",
+      "sudo chown root:root /etc/delivery/*",
+      "sudo delivery-ctl reconfigure",
+      "sudo mv /home/ec2-user/builder_key* /etc/delivery/",
+      "sudo delivery-ctl create-enterprise delivery --ssh-pub-key-file=/etc/delivery/builder_key.pub > /home/ec2-user/admin.creds",
+      "sudo delivery-ctl install-build-node --fqdn ${aws_instance.build_nodes.0.public_dns} --username chef --installer /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm --password chef --overwrite-registration",
+      "sudo delivery-ctl install-build-node --fqdn ${aws_instance.build_nodes.1.public_dns} --username chef --installer /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm --password chef --overwrite-registration",
+      "sudo delivery-ctl install-build-node --fqdn ${aws_instance.build_nodes.2.public_dns} --username chef --installer /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm --password chef --overwrite-registration",
+      "sudo chown ec2-user:ec2-user /home/ec2-user/admin.creds",
+    ]
+  }
+  provisioner "local-exec" {
+    command = "scp -oStrictHostKeyChecking=no -i .keys/${var.aws_key_pair_name}.pem ${var.aws_ami_user}@${aws_instance.chef_automate.public_dns}:~/admin.creds ./"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -400,7 +400,7 @@ resource "null_resource" "automate_setup" {
     inline = [
       "sudo curl -o /home/ec2-user/chefdk-0.17.17-1.el7.x86_64.rpm -L https://packages.chef.io/stable/el/7/chefdk-0.17.17-1.el7.x86_64.rpm",
       "sudo mkdir /etc/delivery",
-      "sudo cp /home/ec2-user/chef_automate.pem /etc/delivery",
+      "sudo cp /home/ec2-user/chef_automate.pem /etc/delivery/delivery.pem",
       "sudo cp /home/ec2-user/delivery.rb /etc/delivery",
       "sudo mkdir -p /var/opt/delivery/license/",
       "sudo cp /home/ec2-user/chef_automate.license /var/opt/delivery/license/delivery.license",

--- a/main.tf
+++ b/main.tf
@@ -314,7 +314,7 @@ resource "aws_instance" "build_nodes" {
   provisioner "remote-exec" {
     inline = [
       "sudo useradd chef -p \\$6\\$sBhkyEwj\\$NZAqoAs3zFOygX2nH.wouLwe6h3zMgXnp3IVgLCTzrsJn1hVUU8qmH3kzyQCAVwtRGOQpfrZKvwtUx\\/1qWZjq0",
-      "sudo echo 'chef ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/80-chef-users",
+      "sudo bash -c 'echo \"chef ALL=(ALL) NOPASSWD:ALL\" > /etc/sudoers.d/80-chef-users'",
       "sudo sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
       "sudo service sshd restart",
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,10 @@ variable "automate_tag" { default = "terraform_automate" }
 # unique identifier for this instance of Chef Automate
 variable "automate_instance_id" { default = "override_me" }
 
+variable "aws_build_node_instance_type" {
+  default = "t2.medium"
+}
+
 variable "aws_instance_type" {
   default = "m4.xlarge"
 }
@@ -30,7 +34,8 @@ variable "aws_ami_user" {
 }
 
 variable "aws_ami_rhel" { default = "ami-a3fa16c3" } #rhel72 US-west2
- 
+# rhel 72 US-east-1 = ami-85241def
+
 # need to update these for rhel7
 variable "centos-6-amis" {
   default = {


### PR DESCRIPTION
Unfortunately the way we were building delivery with delivery-ctl setup always generates a user prompt asking for Enterprise. I had to change it to populate the delivery.rb file, reconfigure, then create an enterprise.

As well delivery-ctl install-build-node doesn't like to do ssh only auth from what I can tell. I'll take another look at that tomorrow.

I successfully stood up an automate cluster with this, the only issue being the build nodes don't install and register with the chef server yet - I failed at adding the chef user to the sudoers file apparently. Once thats fixed I believe we'll have a working automate cluster with 3 build nodes.
