### PR TITLE
Terraform 0.7.x deprecation fixes and a race condition fix

### DIFF
--- a/cookbooks/chef_server/metadata.rb
+++ b/cookbooks/chef_server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license 'all_rights'
 description 'Installs/Configures chef server'
 long_description 'Installs/Configures chef server'
-version '0.1.0'
+version '0.1.1'
 
 depends 'chef-ingredient'
 depends 'chef-server-ctl'

--- a/cookbooks/chef_server/recipes/default.rb
+++ b/cookbooks/chef_server/recipes/default.rb
@@ -20,5 +20,6 @@ end
 include_recipe 'chef_server::_manage'
 #include_recipe 'chef_server::_reporting'
 include_recipe 'chef_server::_push_server'
+wait_for_server_startup "because"
 include_recipe 'chef_server::_chef_delivery_org_setup'
 include_recipe 'chef_server::_save_secrets'

--- a/cookbooks/chef_server/resources/wait_for_server_startup.rb
+++ b/cookbooks/chef_server/resources/wait_for_server_startup.rb
@@ -1,0 +1,38 @@
+resource_name :wait_for_server_startup
+provides :wait_for_server_startup
+
+action :create do
+  wait_for_server_startup
+end
+
+action_class do
+  def wait_for_server_startup
+    Chef::Log.info('Waiting for the Chef server to be ready')
+    attempts = 90
+    STDOUT.sync = true
+    (0..attempts).each do |attempt|
+      break if erchef_ready?
+
+      sleep 1
+      print '.'
+      if attempt == attempts
+        raise "Gave up waiting for the Chef server to be ready after #{attempt} attempts"
+      end
+    end
+  end
+
+  def erchef_ready?
+    require 'open-uri'
+    require 'openssl'
+    require 'json'
+
+    begin
+      server_status = JSON.parse(open('https://localhost/_status', ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE).read)
+    rescue Exception
+      return false
+    end
+
+    return true if server_status['status'] == 'pong'
+    false
+  end
+end

--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,7 @@ data "template_file" "chef_server" {
 resource "aws_instance" "chef_server" {
   connection {
     user     = "${var.aws_ami_user}"
-    key_file = ".keys/${var.aws_key_pair_name}.pem"
+    private_key = "${file(".keys/${var.aws_key_pair_name}.pem")}"
   }
 
   ami             = "${var.aws_ami_rhel}"
@@ -285,7 +285,7 @@ resource "aws_instance" "chef_server" {
 resource "aws_instance" "build_nodes" {
   connection {
     user     = "${var.aws_ami_user}"
-    key_file = ".keys/${var.aws_key_pair_name}.pem"
+    private_key = "${file(".keys/${var.aws_key_pair_name}.pem")}"
   }
 
   ami             = "${var.aws_ami_rhel}"
@@ -335,7 +335,7 @@ data "template_file" "delivery_validator" {
 resource "aws_instance" "chef_automate" {
   connection {
     user     = "${var.aws_ami_user}"
-    key_file = ".keys/${var.aws_key_pair_name}.pem"
+    private_key = "${file(".keys/${var.aws_key_pair_name}.pem")}"
   }
 
   ami             = "${var.aws_ami_rhel}"
@@ -385,8 +385,8 @@ resource "aws_instance" "chef_automate" {
     run_list = ["chef_automate::default"]
     node_name = "${aws_instance.chef_automate.public_dns}"
     server_url = "https://${aws_instance.chef_server.public_dns}/organizations/delivery"
-    validation_client_name = "delivery-validator"
-    validation_key = "${data.template_file.delivery_validator.rendered}"
+    user_name = "delivery-validator"
+    user_key = "${data.template_file.delivery_validator.rendered}"
   }
   provisioner "local-exec" {
     command = "scp -oStrictHostKeyChecking=no -i .keys/${var.aws_key_pair_name}.pem ${var.aws_ami_user}@${aws_instance.chef_automate.public_dns}:~/admin.creds ./"


### PR DESCRIPTION
1.  The `key_file` property in TF was deprecated in favor of the `private_key` property
2.  The `validation_client_name` and `validation_key` were deprecated in favor of `user_name` and `user_key`
3.  Add a `wait_for_server_startup` custom resource and run it after push jobs install
